### PR TITLE
feat: add webhook configuration support

### DIFF
--- a/api/server/index.js
+++ b/api/server/index.js
@@ -55,7 +55,14 @@ const startServer = async () => {
 
   /* Middleware */
   app.use(noIndex);
-  app.use(express.json({ limit: '3mb' }));
+  app.use(
+    express.json({
+      limit: '3mb',
+      verify: (req, _res, buf) => {
+        req.rawBody = buf;
+      },
+    }),
+  );
   app.use(express.urlencoded({ extended: true, limit: '3mb' }));
   app.use(mongoSanitize());
   app.use(cors());
@@ -119,6 +126,7 @@ const startServer = async () => {
   app.use('/api/memories', routes.memories);
   app.use('/api/tags', routes.tags);
   app.use('/api/mcp', routes.mcp);
+  app.use('/api/webhooks', routes.webhooks);
 
   // Add the error controller one more time after all routes
   app.use(errorController);

--- a/api/server/routes/index.js
+++ b/api/server/routes/index.js
@@ -26,6 +26,7 @@ const edit = require('./edit');
 const keys = require('./keys');
 const user = require('./user');
 const mcp = require('./mcp');
+const webhooks = require('./webhooks');
 
 module.exports = {
   edit,
@@ -56,4 +57,5 @@ module.exports = {
   categories,
   staticRoute,
   mcp,
+  webhooks,
 };

--- a/api/server/routes/webhooks.js
+++ b/api/server/routes/webhooks.js
@@ -1,0 +1,128 @@
+const express = require('express');
+const crypto = require('crypto');
+const PQueue = require('p-queue');
+const { logger } = require('@librechat/data-schemas');
+const { EModelEndpoint } = require('librechat-data-provider');
+const { getCustomConfig } = require('~/server/services/Config');
+const { loadAgent } = require('~/models/Agent');
+const { findUser } = require('~/models');
+const AgentController = require('~/server/controllers/agents/request');
+const { initializeClient } = require('~/server/services/Endpoints/agents');
+const addTitle = require('~/server/services/Endpoints/agents/title');
+const { Writable } = require('stream');
+
+const router = express.Router();
+const queue = new PQueue({ concurrency: 1 });
+
+function verifyAuth(req, auth) {
+  if (!auth) {
+    return true;
+  }
+
+  switch (auth.type) {
+    case 'github': {
+      const alg = auth.algorithm || 'sha256';
+      const signatureHeader = auth.signature_header ||
+        (alg === 'sha256' ? 'x-hub-signature-256' : 'x-hub-signature');
+      const signature = req.get(signatureHeader);
+      if (!signature || !req.rawBody) {
+        return false;
+      }
+      const hmac = crypto.createHmac(alg, auth.secret).update(req.rawBody).digest('hex');
+      const expected = `${alg}=${hmac}`;
+      try {
+        return crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
+      } catch {
+        return false;
+      }
+    }
+    case 'header': {
+      const headerName = auth.header || 'authorization';
+      const value = req.get(headerName) || '';
+      const expected = auth.prefix ? `${auth.prefix}${auth.secret}` : auth.secret;
+      return value === expected;
+    }
+    case 'microsoft': {
+      const clientState = req.body?.value?.[0]?.clientState;
+      return clientState === auth.clientState;
+    }
+    default:
+      return true;
+  }
+}
+
+async function processWebhook({ req, webhookConfig, name, userId, payload }) {
+  try {
+    const prefix = webhookConfig.prompt ? `${webhookConfig.prompt}\n\n` : '';
+    const text = `${prefix}${JSON.stringify(payload)}`;
+
+    const agentReq = {
+      user: { id: userId },
+      headers: req.headers,
+      body: {
+        text,
+        endpoint: EModelEndpoint.agents,
+        agent_id: webhookConfig.agent_id,
+        endpointOption: {
+          endpoint: EModelEndpoint.agents,
+          agent_id: webhookConfig.agent_id,
+          agent: loadAgent({
+            req: { user: { id: userId } },
+            agent_id: webhookConfig.agent_id,
+            endpoint: EModelEndpoint.agents,
+          }),
+          model_parameters: {},
+        },
+      },
+    };
+
+    const dummyRes = new Writable({
+      write(_chunk, _enc, cb) {
+        cb();
+      },
+    });
+    dummyRes.write = () => {};
+    dummyRes.end = () => {};
+    dummyRes.setHeader = () => {};
+    dummyRes.status = () => dummyRes;
+    dummyRes.json = () => {};
+    dummyRes.on = () => {};
+    dummyRes.removeListener = () => {};
+
+    await AgentController(agentReq, dummyRes, () => {}, initializeClient, addTitle);
+  } catch (error) {
+    logger.error(`[webhook:${name}] processing failed`, error);
+  }
+}
+
+router.all('/:name', async (req, res) => {
+  const { name } = req.params;
+  const config = await getCustomConfig();
+  const webhookConfig = config?.webhooks?.[name];
+
+  if (!webhookConfig) {
+    return res.status(404).json({ error: 'Webhook not configured' });
+  }
+
+  if (req.method === 'GET' && req.query.validationToken) {
+    return res.status(200).send(req.query.validationToken);
+  }
+
+  if (!verifyAuth(req, webhookConfig.auth)) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  let userId = 'system';
+  if (webhookConfig.user) {
+    const user = await findUser({ email: webhookConfig.user });
+    // If your deployment uses email as the user identifier, the lookup above will simply return the same value
+    userId = user?._id?.toString() || webhookConfig.user;
+  }
+
+  const payload = req.body;
+  res.status(202).json({ ok: true });
+
+  queue.add(() => processWebhook({ req, webhookConfig, name, userId, payload }));
+});
+
+module.exports = router;

--- a/librechat.example.yaml
+++ b/librechat.example.yaml
@@ -137,6 +137,26 @@ actions:
     - "librechat.ai"
     - "google.com"
 
+# Example Webhooks configuration
+webhooks:
+  email_received:
+    agent_id: 'agent-email'
+    user: 'admin@example.com' # user's email; if your ID is the same as email, reuse it here
+    prompt: |-
+      A new email has arrived. Summarize it and note any required actions.
+    auth:
+      type: microsoft
+      clientState: '${MS_CLIENT_STATE}'
+  github_issue:
+    agent_id: 'agent-github'
+    user: 'admin@example.com'
+    prompt: |-
+      A new GitHub issue was opened. Review the issue and propose next steps.
+    auth:
+      type: github
+      secret: '${GITHUB_WEBHOOK_SECRET}'
+      algorithm: sha256
+
 # Example MCP Servers Object Structure
 # mcpServers:
 #   everything:

--- a/packages/data-provider/src/config.ts
+++ b/packages/data-provider/src/config.ts
@@ -6,6 +6,7 @@ import { specsConfigSchema, TSpecsConfig } from './models';
 import { fileConfigSchema } from './file-config';
 import { FileSources } from './types/files';
 import { MCPServersSchema } from './mcp';
+import { WebhooksSchema } from './webhooks';
 
 export const defaultSocialLogins = ['google', 'facebook', 'openid', 'github', 'discord', 'saml'];
 
@@ -757,6 +758,7 @@ export const configSchema = z.object({
   includedTools: z.array(z.string()).optional(),
   filteredTools: z.array(z.string()).optional(),
   mcpServers: MCPServersSchema.optional(),
+  webhooks: WebhooksSchema.optional(),
   interface: intefaceSchema,
   turnstile: turnstileSchema.optional(),
   fileStrategy: fileSourceSchema.default(FileSources.local),

--- a/packages/data-provider/src/index.ts
+++ b/packages/data-provider/src/index.ts
@@ -13,6 +13,7 @@ export * from './generate';
 export * from './models';
 /* mcp */
 export * from './mcp';
+export * from './webhooks';
 /* memory */
 export * from './memory';
 /* RBAC */

--- a/packages/data-provider/src/webhooks.ts
+++ b/packages/data-provider/src/webhooks.ts
@@ -1,0 +1,44 @@
+import { z } from 'zod';
+
+const githubAuthSchema = z.object({
+  type: z.literal('github'),
+  secret: z.string(),
+  algorithm: z.enum(['sha1', 'sha256']).default('sha256'),
+  signature_header: z.string().optional(),
+});
+
+const headerAuthSchema = z.object({
+  type: z.literal('header'),
+  secret: z.string(),
+  header: z.string().default('authorization'),
+  prefix: z.string().optional(),
+});
+
+const microsoftAuthSchema = z.object({
+  type: z.literal('microsoft'),
+  clientState: z.string(),
+});
+
+export const webhookAuthSchema = z.discriminatedUnion('type', [
+  githubAuthSchema,
+  headerAuthSchema,
+  microsoftAuthSchema,
+]);
+
+export const webhookSchema = z.object({
+  agent_id: z.string(),
+  /**
+   * Email address of the user to attribute the webhook message to.
+   * If your system uses emails as user IDs, use the same value here.
+   */
+  user: z.string().optional(),
+  prompt: z.string().optional(),
+  auth: webhookAuthSchema.optional(),
+});
+
+export const WebhooksSchema = z.record(webhookSchema);
+
+export type TWebhookAuth = z.infer<typeof webhookAuthSchema>;
+export type TWebhookConfig = z.infer<typeof webhookSchema>;
+export type TWebhooksConfig = z.infer<typeof WebhooksSchema>;
+


### PR DESCRIPTION
## Summary
- support configurable webhook auth and user lookup by email
- queue webhook processing to respond immediately while launching agent chats
- document webhook usage with auth and email-based user mapping

## Testing
- `npm run test:api` *(fails: 60 failed, 14 passed, 74 total)*

------
https://chatgpt.com/codex/tasks/task_e_6896994ba5388333bdb92cd0dc36c615